### PR TITLE
convert entries to list of objects

### DIFF
--- a/base.json
+++ b/base.json
@@ -4,26 +4,26 @@
     "kind": "script_catalog"
   },
   "catalog_name": "base",
-  "entries": {
-    "crow-studies": {
+  "entries": [
+    {
       "project_name": "crow-studies",
       "project_url": "https://github.com/monome/crow-studies",
       "description": "crow examples",
       "discussion_url": "https://monome.org/docs/crow/norns",
       "tags": ["study", "demo"]
     },
-    "softcut-studies": {
+    {
       "project_name": "softcut-studies",
       "project_url": "https://github.com/monome/softcut-studies",
       "description": "softcut examples",
       "discussion_url": "https://llllllll.co/t/norns-softcut-studies/23585",
       "tags": ["study", "demo"]
     },
-    "we": {
+    {
       "project_name": "we",
       "project_url": "https://github.com/monome/we.git",
       "description": "collected projects (legacy)",
       "tags": ["study", "demo", "lib", "test"]
     }
-  }
+  ]
 }

--- a/community.json
+++ b/community.json
@@ -5,14 +5,14 @@
   },
   "catalog_name": "community",
   "date": "0001-01-01T00:00:00Z",
-  "entries": {
-    "ack": {
+  "entries": [
+    {
       "project_name": "ack",
       "project_url": "https://github.com/antonhornquist/ack",
       "project_author": "Anton Hörnquist (jah)",
       "description": "sample player engine"
     },
-    "arcify": {
+    {
       "project_name": "arcify",
       "project_url": "https://github.com/mimetaur/arcify",
       "author": "Nathan (mimetaur)",
@@ -21,7 +21,7 @@
       "tags": ["lib"],
       "origin": "lines"
     },
-    "ash": {
+    {
       "project_name": "ash",
       "project_url": "https://github.com/tehn/ash",
       "author": "Brian Crabtree (tehn)",
@@ -30,7 +30,7 @@
       "tags": ["arc", "grid", "looper", "drum", "synth"],
       "origin": "lines"
     },
-    "arp_index": {
+    {
       "project_name": "arp_index",
       "project_url": "https://github.com/markwheeler/arp_index",
       "author": "Mark Eats (markeats)",
@@ -38,7 +38,7 @@
       "discussion_url": "https://llllllll.co/t/the-arp-index/25182",
       "origin": "lines"
     },
-    "awake": {
+    {
       "project_name": "awake",
       "project_url": "https://github.com/tehn/awake",
       "author": "Brian Crabtree (tehn)",
@@ -46,7 +46,7 @@
       "discussion_url": "https://llllllll.co/t/awake/21022",
       "origin": "lines"
     },
-    "bounds": {
+    {
       "project_name": "bounds",
       "project_url": "https://github.com/justmat/bounds",
       "author": "Matthew (Justmat)",
@@ -54,7 +54,7 @@
       "discussion_url": "https://llllllll.co/t/23336",
       "origin": "lines"
     },
-    "cccccccc": {
+    {
       "project_name": "cccccccc",
       "project_url": "https://github.com/ypxk/cccccccc/",
       "author": "ypxkap",
@@ -63,7 +63,7 @@
       "tags": ["arc"],
       "origin": "lines"
     },
-    "compass": {
+    {
       "project_name": "compass",
       "project_url": "https://github.com/oliviercreurer/compass",
       "author": "Olivier",
@@ -71,7 +71,7 @@
       "discussion_url": "https://llllllll.co/t/compass/25192",
       "tags": ["looper", "sequencer"]
     },
-    "circles": {
+    {
       "project_name": "circles",
       "project_url": "https://github.com/JakeCarter/circles",
       "author": "Jake (jakecarter)",
@@ -80,7 +80,7 @@
       "tags": ["crow"],
       "origin": "lines"
     },
-    "clarck": {
+    {
       "project_name": "clarck",
       "project_url": "https://github.com/okyeron/clarck",
       "author": "steven noreyko (okyeron)",
@@ -89,7 +89,7 @@
       "tags": ["arc"],
       "origin": "lines"
     },
-    "cranes": {
+    {
       "project_name": "cranes",
       "project_url": "https://github.com/dndrks/cranes",
       "author": "jai lai bookie (Dan_Derks)",
@@ -97,7 +97,7 @@
       "discussion_url": "https://llllllll.co/t/21207",
       "origin": "lines"
     },
-    "drum_room": {
+    {
       "project_name": "drum_room",
       "project_url": "https://github.com/markwheeler/drum_room",
       "author": "Mark Eats (markeats)",
@@ -106,7 +106,7 @@
       "tags": ["drum"],
       "origin": "lines"
     },
-    "dunes": {
+    {
       "project_name": "dunes",
       "project_url": "https://github.com/oliviercreurer/dunes",
       "author": "Olivier Creurer (Olivier)",
@@ -114,7 +114,7 @@
       "discussion_url": "https://llllllll.co/t/dunes/24790",
       "origin": "lines"
     },
-    "easygrain": {
+    {
       "project_name": "easygrain",
       "project_url": "https://github.com/mhetrick/easygrain",
       "author": "Michael Hetrick (trickyflemming)",
@@ -122,7 +122,7 @@
       "discussion_url": "https://llllllll.co/t/easygrain/21047",
       "origin": "lines"
     },
-    "fm7": {
+    {
       "project_name": "fm7",
       "project_url": "https://github.com/lazzarello/fm7",
       "author": "Lee Azzarello (lazzarello)",
@@ -131,7 +131,7 @@
       "tags": ["synth", "midi"],
       "origin": "lines"
     },
-    "foulplay": {
+    {
       "project_name": "foulplay",
       "project_url": "https://github.com/justmat/foulplay",
       "author": "Matthew (Justmat)",
@@ -139,7 +139,7 @@
       "discussion_url": "https://llllllll.co/t/foulplay/21081",
       "origin": "lines"
     },
-    "fugu": {
+    {
       "project_name": "fugu",
       "project_url": "https://github.com/itsyourbedtime/fugu",
       "author": "its your bedtime (its_your_bedtime)",
@@ -148,7 +148,7 @@
       "tags": ["sequencer"],
       "origin": "lines"
     },
-    "gemini": {
+    {
       "project_name": "gemini",
       "project_url": "https://github.com/mhetrick/gemini/",
       "author": "Michael Hetrick (trickyflemming)",
@@ -156,7 +156,7 @@
       "discussion_url": "https://llllllll.co/t/gemini/21086",
       "origin": "lines"
     },
-    "glut": {
+    {
       "project_name": "glut",
       "project_url": "https://github.com/artfwo/glut",
       "author": "artfwo",
@@ -165,7 +165,7 @@
       "tags": ["granular"],
       "origin": "lines"
     },
-    "haven": {
+    {
       "project_name": "haven",
       "project_url": "https://github.com/tai-studio/haven",
       "author": "Till Bovermann (LFSaw)",
@@ -173,7 +173,7 @@
       "discussion_url": "https://llllllll.co/t/haven/21285",
       "origin": "lines"
     },
-    "hid_demo": {
+    {
       "project_name": "hid_demo",
       "project_url": "https://github.com/okyeron/hid-demo/",
       "author": "steven noreyko (okyeron)",
@@ -182,7 +182,7 @@
       "tags": ["hid", "demo"],
       "origin": "lines"
     },
-    "isoseq": {
+    {
       "project_name": "isoseq",
       "project_url": "https://github.com/carvingCode/isoseq",
       "author": "Randy Brown (carvingcode)",
@@ -191,7 +191,7 @@
       "tags": ["grid"],
       "origin": "lines"
     },
-    "jiffy": {
+    {
       "project_name": "jiffy",
       "project_url": "https://github.com/lukes-anger/jiffy",
       "author": "Luke Sanger (Molotov)",
@@ -199,7 +199,7 @@
       "discussion_url": "https://llllllll.co/t/jiffy/25475",
       "origin": "lines"
     },
-    "kria_midi": {
+    {
       "project_name": "kria_midi",
       "project_url": "https://github.com/junklight/misc",
       "author": "mark john williamson (junklight)",
@@ -208,7 +208,7 @@
       "tag": ["grid", "midi"],
       "origin": "lines"
     },
-    "less_concepts": {
+    {
       "project_name": "less_concepts",
       "project_url": "https://github.com/dndrks/less_concepts",
       "author": "jai lai bookie (Dan_Derks)",
@@ -217,7 +217,7 @@
       "tags": ["ca", "crow", "sequencer"],
       "origin": "lines"
     },
-    "loom": {
+    {
       "project_name": "loom",
       "project_url": "https://github.com/markwheeler/loom/",
       "author": "Mark Eats (markeats)",
@@ -226,7 +226,7 @@
       "tags": ["grid"],
       "origin": "lines"
     },
-    "mangl": {
+    {
       "project_name": "mangl",
       "project_url": "https://github.com/notjustmat/mangl",
       "author": "Matthew (Justmat)",
@@ -235,7 +235,7 @@
       "tags": ["arc", "granular"],
       "origin": "lines"
     },
-    "manifold": {
+    {
       "project_name": "manifold",
       "project_url": "https://github.com/carltesta/manifold",
       "author": "Carl Testa (carltesta)",
@@ -244,7 +244,7 @@
       "tags": ["fx"],
       "origin": "lines"
     },
-    "meadowphysics": {
+    {
       "project_name": "meadowphysics",
       "project_url": "https://github.com/alpha-cactus/meadowphysics",
       "author": "Ryan Hodgman (alphacactus)",
@@ -253,7 +253,7 @@
       "tags": ["grid"],
       "origin": "lines"
     },
-    "mlr": {
+    {
       "project_name": "mlr",
       "project_url": "https://github.com/tehn/mlr",
       "author": "Brian Crabtree (tehn)",
@@ -262,7 +262,7 @@
       "tags": ["sampler"],
       "origin": "lines"
     },
-    "molly_the_poly": {
+    {
       "project_name": "molly_the_poly",
       "project_url": "https://github.com/markwheeler/molly_the_poly",
       "author": "Mark Eats (markeats)",
@@ -271,7 +271,7 @@
       "tags": ["synth", "midi"],
       "origin": "lines"
     },
-    "moln": {
+    {
       "project_name": "moln",
       "project_url": "https://github.com/antonhornquist/moln",
       "author": "Anton Hörnquist (jah)",
@@ -280,7 +280,7 @@
       "tags": ["synth", "midi", "grid", "arc"],
       "origin": "lines"
     },
-    "monitor": {
+    {
       "project_name": "monitor",
       "project_url": "https://github.com/neauoire/monitor",
       "author": "Devine Lu Linvega (neauoire)",
@@ -289,7 +289,7 @@
       "tags": ["midi"],
       "origin": "lines"
     },
-    "norman": {
+    {
       "project_name": "norman",
       "project_url": "https://github.com/crimclark/norman",
       "author": "crim",
@@ -297,7 +297,7 @@
       "discussion_url": "https://llllllll.co/t/norman/22606",
       "origin": "lines"
     },
-    "onehanded": {
+    {
       "project_name": "onehanded",
       "project_url": "https://github.com/mimetaur/onehanded",
       "author": "Nathan (mimetaur)",
@@ -306,7 +306,7 @@
       "tags": ["midi"],
       "origin": "lines"
     },
-    "orbital": {
+    {
       "project_name": "orbital",
       "project_url": "https://github.com/P1505/orbital",
       "author": "P1505",
@@ -314,7 +314,7 @@
       "discussion_url": "https://llllllll.co/t/orbital-norns/21379",
       "origin": "lines"
     },
-    "orca": {
+    {
       "project_name": "orca",
       "project_url": "https://github.com/itsyourbedtime/orca",
       "author": "its your bedtime (its_your_bedtime)",
@@ -323,7 +323,7 @@
       "tags": ["hid", "keyboard"],
       "origin": "lines"
     },
-    "otis": {
+    {
       "project_name": "otis",
       "project_url": "https://github.com/justmat/otis",
       "author": "Matthew (Justmat)",
@@ -332,7 +332,7 @@
       "tags": ["looper"],
       "origin": "lines"
     },
-    "passersby": {
+    {
       "project_name": "passersby",
       "project_url": "https://github.com/markwheeler/passersby",
       "author": "Mark Eats (markeats)",
@@ -341,7 +341,7 @@
       "tags": ["synth", "midi"],
       "origin": "lines"
     },
-    "punchcard": {
+    {
       "project_name": "punchcard",
       "project_url": "https://github.com/neauoire/punchcard",
       "author": "Devine Lu Linvega (neauoire)",
@@ -349,7 +349,7 @@
       "discussion_url": "https://llllllll.co/t/23557",
       "origin": "lines"
     },
-    "reels": {
+    {
       "project_name": "reels",
       "project_url": "https://github.com/itsyourbedtime/reels",
       "author": "its your bedtime (its_your_bedtime)",
@@ -358,7 +358,7 @@
       "tags": ["looper"],
       "origin": "lines"
     },
-    "rebound": {
+    {
       "project_name": "rebound",
       "project_url": "https://github.com/nf/rebound",
       "author": "nf (enneff)",
@@ -367,7 +367,7 @@
       "tags": ["sequencer"],
       "origin": "lines"
     },
-    "sam": {
+    {
       "project_name": "sam",
       "project_url": "https://github.com/justmat/sam",
       "author": "Matthew (Justmat)",
@@ -375,7 +375,7 @@
       "discussion_url": "https://llllllll.co/t/23943",
       "origin": "lines"
     },
-    "seaflex": {
+    {
       "project_name": "seaflex",
       "project_url": "https://github.com/lylepmills/seaflex",
       "author": "Lyle Mills (lylem)",
@@ -384,7 +384,7 @@
       "tags": ["grid"],
       "origin": "lines"
     },
-    "shfts": {
+    {
       "project_name": "shfts",
       "project_url": "https://github.com/rwhaling/shfts",
       "author": "Richard Whaling (germinal)",
@@ -393,7 +393,7 @@
       "tags": ["crow", "grid"],
       "origin": "lines"
     },
-    "step": {
+    {
       "project_name": "step",
       "project_url": "https://github.com/antonhornquist/step",
       "author": "Anton Hörnquist (jah)",
@@ -401,7 +401,7 @@
       "discussion_url": "https://llllllll.co/t/step/21093",
       "origin": "lines"
     },
-    "strides": {
+    {
       "project_name": "strides",
       "project_url": "https://github.com/notjustmat/strides",
       "author": "Matthew (Justmat)",
@@ -409,7 +409,7 @@
       "discussion_url": "https://llllllll.co/t/21101",
       "origin": "lines"
     },
-    "strum": {
+    {
       "project_name": "strum",
       "project_url": "https://github.com/carvingCode/strum",
       "author": "Randy Brown (carvingcode)",
@@ -417,7 +417,7 @@
       "discussion_url": "https://llllllll.co/t/21025",
       "origin": "lines"
     },
-    "sway": {
+    {
       "project_name": "sway",
       "project_url": "https://github.com/carltesta/sway",
       "author": "Carl Testa (carltesta)",
@@ -425,7 +425,7 @@
       "discussion_url": "https://llllllll.co/t/sway/21117",
       "origin": "lines"
     },
-    "takt": {
+    {
       "project_name": "takt",
       "project_url": "https://github.com/itsyourbedtime/takt",
       "author": "igor (its_your_bedtime)",
@@ -433,7 +433,7 @@
       "discussion_url": "https://llllllll.co/t/takt/21032",
       "origin": "lines"
     },
-    "timber": {
+    {
       "project_name": "timber",
       "project_url": "https://github.com/markwheeler/timber",
       "author": "Mark Eats (markeats)",
@@ -441,7 +441,7 @@
       "discussion_url": "https://llllllll.co/t/21407",
       "origin": "lines"
     },
-    "timeparty": {
+    {
       "project_name": "timeparty",
       "project_url": "https://github.com/crimclark/timeparty",
       "author": "crim",
@@ -449,7 +449,7 @@
       "discussion_url": "https://llllllll.co/t/timeparty/22837",
       "origin": "lines"
     },
-    "traffic": {
+    {
       "project_name": "traffic",
       "project_url": "https://github.com/ypxk/traffic",
       "author": "ypxkap",
@@ -457,7 +457,7 @@
       "discussion_url": "https://llllllll.co/t/traffic/21262",
       "origin": "lines"
     },
-    "tuner": {
+    {
       "project_name": "tuner",
       "project_url": "https://github.com/markwheeler/tuner",
       "author": "Mark Eats (markeats)",
@@ -465,7 +465,7 @@
       "discussion_url": "https://llllllll.co/t/tuner/21088",
       "origin": "lines"
     },
-    "tunnels": {
+    {
       "project_name": "tunnels",
       "project_url": "https://github.com/speakerdamage/tunnels",
       "author": "Caulen (speakerdamage)",
@@ -473,7 +473,7 @@
       "discussion_url": "https://llllllll.co/t/tunnels/21973",
       "origin": "lines"
     },
-    "uhf": {
+    {
       "project_name": "uhf",
       "project_url": "https://github.com/speakerdamage/uhf",
       "author": "Caulen (speakerdamage)",
@@ -482,7 +482,7 @@
       "tags": ["tape"],
       "origin": "lines"
     },
-    "vials": {
+    {
       "project_name": "vials",
       "project_url": "https://github.com/nattog/vials",
       "author": "Guy (nattog)",
@@ -490,7 +490,7 @@
       "discussion_url": "https://llllllll.co/t/vials/23109",
       "origin": "lines"
     },
-    "zellen": {
+    {
       "project_name": "zellen",
       "project_url": "https://github.com/sarweiler/zellen",
       "author": "Sven (sbaio)",
@@ -498,5 +498,5 @@
       "discussion_url": "https://llllllll.co/t/zellen/21107",
       "origin": "lines"
     }
-  }
+  ]
 }


### PR DESCRIPTION
this change should prevent the hard to diagnose error which occurred when the project names didn't match between map key and `project_name` property  

once merged these catalogs will only work when paired with maiden v1.0b2:
https://github.com/monome/maiden/releases/tag/v1.0b2