### PR TITLE
remove unused origin property

### DIFF
--- a/community.json
+++ b/community.json
@@ -12,16 +12,14 @@
       "author": "David Kettler (21echoes)",
       "description": "send control voltages out of crow",
       "discussion_url": "https://llllllll.co/t/42190",
-      "tags": ["crow", "arc"],
-      "origin": "lines"
+      "tags": ["crow", "arc"]
     },
     {
       "project_name": "abacus",
       "project_url": "https://github.com/schollz/abacus",
       "author": "Zack Scholl (infinitedigits)",
       "description": "sequence rows of beats with samples",
-      "discussion_url": "https://llllllll.co/t/abacus/37871",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/abacus/37871"
     },
     {
       "project_name": "ack",
@@ -34,8 +32,7 @@
       "project_url": "https://github.com/schollz/amen",
       "author": "Zack Scholl (infinitedigits)",
       "description": "sampler and mangler of loops",
-      "discussion_url": "https://llllllll.co/t/amen/43746",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/amen/43746"
     },
     {
       "project_name": "animator",
@@ -43,8 +40,7 @@
       "author": "Tim Clark (crim)",
       "description": "2D Polyphonic step sequencer for grids",
       "discussion_url": "https://llllllll.co/t/animator/28242",
-      "tags": ["grid", "sequencer", "crow", "midi"],
-      "origin": "lines"
+      "tags": ["grid", "sequencer", "crow", "midi"]
     },
     {
       "project_name": "arcify",
@@ -52,8 +48,7 @@
       "author": "Nathan (mimetaur)",
       "description": "map arc encoders to up to four parameters (eight with a shift key)",
       "discussion_url": "https://llllllll.co/t/arcify/22133",
-      "tags": ["lib"],
-      "origin": "lines"
+      "tags": ["lib"]
     },
     {
       "project_name": "arcologies",
@@ -61,8 +56,7 @@
       "author": "@tyleretters",
       "description": "an interactive environment for designing 2d sound arcologies with norns and grid",
       "discussion_url": "https://l.llllllll.co/arcologies",
-      "tags": ["grid", "sequencer", "generator"],
-      "origin": "lines"
+      "tags": ["grid", "sequencer", "generator"]
     },
     {
       "project_name": "ash",
@@ -70,48 +64,42 @@
       "author": "Brian Crabtree (tehn)",
       "description": "a small collection",
       "discussion_url": "https://llllllll.co/t/ash-a-small-collection/21349",
-      "tags": ["arc", "grid", "looper", "drum", "synth"],
-      "origin": "lines"
+      "tags": ["arc", "grid", "looper", "drum", "synth"]
     },
     {
       "project_name": "arp_index",
       "project_url": "https://github.com/markwheeler/arp_index",
       "author": "Mark Eats (markeats)",
       "description": "check stocks and make music",
-      "discussion_url": "https://llllllll.co/t/the-arp-index/25182",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/the-arp-index/25182"
     },
     {
       "project_name": "automs70",
       "project_url": "https://github.com/pangrus/automs70",
       "author": "pangrus",
       "description": "automate MS-70 CDR parameters",
-      "discussion_url": "https://llllllll.co/t/automs70/39686",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/automs70/39686"
     },
     {
       "project_name": "awake",
       "project_url": "https://github.com/tehn/awake",
       "author": "Brian Crabtree (tehn)",
       "description": "time changes",
-      "discussion_url": "https://llllllll.co/t/awake/21022",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/awake/21022"
     },
     {
       "project_name": "awake-passersby",
       "project_url": "https://github.com/nattog/awake-passersby",
       "author": "Brian Crabtree (tehn)/Guy (nattog)",
       "description": "time drifting",
-      "discussion_url": "https://llllllll.co/t/awake/21022/139",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/awake/21022/139"
     },
     {
       "project_name": "awake-rings",
       "project_url": "https://github.com/GoneCaving/awake-rings",
       "author": "Brian Crabtree (tehn)/Duncan (GoneCaving)",
       "description": "chimes past",
-      "discussion_url": "https://llllllll.co/t/awake/21022/38",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/awake/21022/38"
     },
     {
       "project_name": "bakeneko",
@@ -119,16 +107,14 @@
       "author": "@tyleretters",
       "description": "a haunted drummer companion",
       "discussion_url": "https://l.llllllll.co/bakeneko",
-      "tags": ["sequencer", "generator"],
-      "origin": "lines"
+      "tags": ["sequencer", "generator"]
     },
     {
       "project_name": "barcode",
       "project_url": "https://github.com/schollz/barcode",
       "author": "Zack Scholl (infinitedigits)",
       "description": "loops sounds into six lfo-modulated voices",
-      "discussion_url": "https://llllllll.co/t/barcode/35297",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/barcode/35297"
     },
     {
       "project_name": "barycenter",
@@ -136,8 +122,7 @@
       "author": "Yancy Way (echophon)",
       "description": "orbital motion sequencing",
       "discussion_url": "https://llllllll.co/t/barycenter/35980",
-      "tags": ["sequencer"],
-      "origin": "lines"
+      "tags": ["sequencer"]
     },
     {
       "project_name": "b-b-b-b-beat",
@@ -145,8 +130,7 @@
       "author": "Ken Frederick (frederickk)",
       "description": "Beat repeater with some glitch",
       "discussion_url": "https://llllllll.co/t/35047",
-      "tags": ["softcut"],
-      "origin": "lines"
+      "tags": ["softcut"]
     },
     {
       "project_name": "beets",
@@ -154,16 +138,14 @@
       "author": "Matt Biddulph (mattbiddulph)",
       "description": "drum loop re-sequencer",
       "discussion_url": "https://llllllll.co/t/beets/30069",
-      "tags": ["grid"],
-      "origin": "lines"
+      "tags": ["grid"]
     },
     {
       "project_name": "benjolis",
       "project_url": "https://github.com/scazan/benjolis",
       "author": "scaxan",
       "description": "chaotic synth",
-      "discussion_url": "https://llllllll.co/t/benjolis/28061",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/benjolis/28061"
     },
     {
       "project_name": "blippoo",
@@ -171,32 +153,28 @@
       "author": "Colin Drake (cfd90)",
       "description": "blippoo box clone",
       "discussion_url": "https://llllllll.co/t/41107",
-      "tags": ["synth"],
-      "origin": "lines"
+      "tags": ["synth"]
     },
     {
       "project_name": "blndr",
       "project_url": "https://github.com/schollz/blndr",
       "author": "Zack Scholl (infinitedigits)",
       "description": "a quantized delay with time bending effects",
-      "discussion_url": "https://llllllll.co/t/blndr/35106",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/blndr/35106"
     },
     {
       "project_name": "boingg",
       "project_url": "https://github.com/justmat/boingg",
       "author": "Mat (Justmat)",
       "description": "a bouncing ball sequencer",
-      "discussion_url": "https://llllllll.co/t/boingg/26536",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/boingg/26536"
     },
     {
       "project_name": "bounds",
       "project_url": "https://github.com/justmat/bounds",
       "author": "Mat (Justmat)",
       "description": "stereo delay/looper",
-      "discussion_url": "https://llllllll.co/t/23336",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/23336"
     },
     {
       "project_name": "breakthrough",
@@ -204,8 +182,7 @@
       "author": "tomw",
       "description": "sequencer / game",
       "discussion_url": "https://llllllll.co/t/breakthrough/39196",
-      "tags": ["sequencer"],
-      "origin": "lines"
+      "tags": ["sequencer"]
     },
     {
       "project_name": "buoys",
@@ -213,8 +190,7 @@
       "author": "Lyle Mills (lylem)",
       "description": "tidal influencer/activator/lightshow",
       "discussion_url": "https://llllllll.co/t/37639",
-      "tags": ["grid", "arc", "crow", "midi"],
-      "origin": "lines"
+      "tags": ["grid", "arc", "crow", "midi"]
     },
     {
       "project_name": "caliper",
@@ -222,8 +198,7 @@
       "author": "kenji garland (synthetiv)",
       "description": "v/oct calibration assistant",
       "discussion_url": "https://llllllll.co/t/caliper/31353",
-      "tags": ["crow"],
-      "origin": "lines"
+      "tags": ["crow"]
     },
     {
       "project_name": "cccccccc",
@@ -231,8 +206,7 @@
       "author": "ypxkap",
       "description": "ccs for arc’s dials",
       "discussion_url": "https://llllllll.co/t/cccccccc/22271",
-      "tags": ["arc"],
-      "origin": "lines"
+      "tags": ["arc"]
     },
     {
       "project_name": "changes",
@@ -240,8 +214,7 @@
       "author": "Mark Eats (markeats)",
       "description": "generate eight connected sine wave lfos and output them over midi",
       "discussion_url": "https://llllllll.co/t/changes/33799",
-      "tags": ["midi", "lfo"],
-      "origin": "lines"
+      "tags": ["midi", "lfo"]
     },
     {
       "project_name": "cheat_codes_2",
@@ -249,8 +222,7 @@
       "author": "dan derks (dan_derks)",
       "description": "a sample playground",
       "discussion_url": "https://l.llllllll.co/cheat-codes-2",
-      "tags": ["grid", "arc", "midi", "crow", "sampler", "looper"],
-      "origin": "lines"
+      "tags": ["grid", "arc", "midi", "crow", "sampler", "looper"]
     },
     {
       "project_name": "circles",
@@ -258,8 +230,7 @@
       "author": "Jake (jakecarter)",
       "description": "move cursor. place circles. make music",
       "discussion_url": "https://llllllll.co/t/22951",
-      "tags": ["crow"],
-      "origin": "lines"
+      "tags": ["crow"]
     },
     {
       "project_name": "clarck",
@@ -267,24 +238,21 @@
       "author": "steven noreyko (okyeron)",
       "description": "a clock for arc4 on norns",
       "discussion_url": "https://llllllll.co/t/clarck/21251",
-      "tags": ["arc"],
-      "origin": "lines"
+      "tags": ["arc"]
     },
     {
       "project_name": "clcks",
       "project_url": "https://github.com/schollz/clcks",
       "author": "Zack Scholl (infinitedigits)",
       "description": "punch-in tempo-locked repeating",
-      "discussion_url": "https://llllllll.co/t/clcks/35732",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/clcks/35732"
     },
     {
       "project_name": "combos",
       "project_url": "https://github.com/justmat/combos",
       "author": "Mat (justmat)",
       "description": "combo scripts",
-      "discussion_url": "https://llllllll.co/t/27020",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/27020"
     },
     {
       "project_name": "compass",
@@ -300,8 +268,7 @@
       "author": "dan derks (dan_derks)",
       "description": "stereo varispeed looper / delay / timeline-smoosher",
       "discussion_url": "https://llllllll.co/t/21207",
-      "tags": ["looper", "grid"],
-      "origin": "lines"
+      "tags": ["looper", "grid"]
     },
     {
       "project_name": "crow_talk",
@@ -309,16 +276,14 @@
       "author": "Mat (justmat)",
       "description": "talk to crow with norns",
       "discussion_url": "https://llllllll.co/t/41560",
-      "tags": ["norns", "crow"],
-      "origin": "lines"
+      "tags": ["norns", "crow"]
     },
     {
       "project_name": "cryptkeeper",
       "project_url": "https://github.com/joelwalden/cryptkeeper",
       "author": "Joel Walden (wardores)",
       "description": "Create and edit crypts for arcologies",
-      "discussion_url": "https://llllllll.co/t/cryptkeeper/39781",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/cryptkeeper/39781"
     },
     {
       "project_name": "cyrene",
@@ -326,8 +291,7 @@
       "author": "David Kettler (21echoes)",
       "description": "a drum sequencer based on Mutable Instruments Grids",
       "discussion_url": "https://llllllll.co/t/31648",
-      "tags": ["drum", "sequencer", "arc", "grid"],
-      "origin": "lines"
+      "tags": ["drum", "sequencer", "arc", "grid"]
     },
     {
       "project_name": "delayyyyyyyy",
@@ -335,16 +299,14 @@
       "author": "Colin Drake (cfd90)",
       "description": "warm delay with modulation and stereo separation",
       "discussion_url": "https://llllllll.co/t/40638",
-      "tags": ["fx"],
-      "origin": "lines"
+      "tags": ["fx"]
     },
     {
       "project_name": "downtown",
       "project_url": "https://github.com/schollz/downtown",
       "author": "Zack Scholl (infinitedigits)",
       "description": "record stereo loops while engine loops",
-      "discussion_url": "https://llllllll.co/t/downtown/40044",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/downtown/40044"
     },
     {
       "project_name": "drift",
@@ -352,8 +314,7 @@
       "author": "Yancy Way (echophon)",
       "description": "drifting relationships creating sequences",
       "discussion_url": "https://llllllll.co/t/drift/36138",
-      "tags": ["sequencer"],
-      "origin": "lines"
+      "tags": ["sequencer"]
     },
     {
       "project_name": "dronecaster",
@@ -361,8 +322,7 @@
       "author": "@tyleretters && @license && the lines community",
       "description": "cast drones & record whatever returns",
       "discussion_url": "https://l.llllllll.co/dronecaster",
-      "tags": ["synth"],
-      "origin": "lines"
+      "tags": ["synth"]
     },
     {
       "project_name": "drum_room",
@@ -370,24 +330,21 @@
       "author": "Mark Eats (markeats)",
       "description": "midi-controlled drum kits",
       "discussion_url": "https://llllllll.co/t/23467",
-      "tags": ["drum"],
-      "origin": "lines"
+      "tags": ["drum"]
     },
     {
       "project_name": "dunes",
       "project_url": "https://github.com/oliviercreurer/dunes",
       "author": "Olivier Creurer (Olivier)",
       "description": "a function sequencer",
-      "discussion_url": "https://llllllll.co/t/dunes/24790",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/dunes/24790"
     },
     {
       "project_name": "easygrain",
       "project_url": "https://github.com/mhetrick/easygrain",
       "author": "Michael Hetrick (trickyflemming)",
       "description": "a simple granulator, now with optional arc support",
-      "discussion_url": "https://llllllll.co/t/easygrain/21047",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/easygrain/21047"
     },
     {
       "project_name": "ekombi",
@@ -419,8 +376,7 @@
       "author": "@tyleretters & @license",
       "description": "i will show you fear in a handful of dust",
       "discussion_url": "https://l.llllllll.co/fiahod",
-      "tags": ["generator"],
-      "origin": "lines"
+      "tags": ["generator"]
     },
     {
       "project_name": "flora",
@@ -428,8 +384,7 @@
       "author": "Jonathan Snyder (jaseknighter)",
       "description": "l-systems sequencer and bandpass-filtered sawtooth engine",
       "discussion_url": "https://llllllll.co/t/40261",
-      "tags": ["sequencer", "synth", "crow"],
-      "origin": "lines"
+      "tags": ["sequencer", "synth", "crow"]
     },
     {
       "project_name": "fm7",
@@ -437,24 +392,21 @@
       "author": "Lee Azzarello (lazzarello)",
       "description": "polyphonic 6 operator fm synth",
       "discussion_url": "https://llllllll.co/t/21395",
-      "tags": ["synth", "midi"],
-      "origin": "lines"
+      "tags": ["synth", "midi"]
     },
     {
       "project_name": "foulplay",
       "project_url": "https://github.com/justmat/foulplay",
       "author": "Mat (Justmat)",
       "description": "euclidean rhythms with logic and probability",
-      "discussion_url": "https://llllllll.co/t/foulplay/21081",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/foulplay/21081"
     },
     {
       "project_name": "foundry",
       "project_url": "https://github.com/csboling/foundry",
       "author": "Sam Boling (csboling)",
       "description": "Font / glyph catalog",
-      "discussion_url": "https://llllllll.co/t/foundry-font-visualizer/33933",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/foundry-font-visualizer/33933"
     },
     {
       "project_name": "fugarc",
@@ -462,8 +414,7 @@
       "author": "Morten Wagner (popgoblin)",
       "description": "fugu meets awake sequencer",
       "discussion_url": "https://llllllll.co/t/fugarc/34446",
-      "tags": ["sequencer"],
-      "origin": "lines"
+      "tags": ["sequencer"]
     },
     {
       "project_name": "fugu",
@@ -471,24 +422,21 @@
       "author": "its your bedtime (its_your_bedtime)",
       "description": "multi playhead sequencer",
       "discussion_url": "https://llllllll.co/t/21033",
-      "tags": ["sequencer"],
-      "origin": "lines"
+      "tags": ["sequencer"]
     },
     {
       "project_name": "gemini",
       "project_url": "https://github.com/mhetrick/gemini/",
       "author": "Michael Hetrick (trickyflemming)",
       "description": "twin granulators. watch them race.",
-      "discussion_url": "https://llllllll.co/t/gemini/21086",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/gemini/21086"
     },
     {
       "project_name": "glitchlets",
       "project_url": "https://github.com/schollz/glitchlets",
       "author": "Zack Scholl (infinitedigits)",
       "description": "lets glitch with glitchlets.",
-      "discussion_url": "https://llllllll.co/t/glitchlets/37069",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/glitchlets/37069"
     },
     {
       "project_name": "glut",
@@ -496,16 +444,14 @@
       "author": "artfwo",
       "description": "granular synth inspired by mlr/rove, grainfields 20 and loomer cumulus",
       "discussion_url": "https://llllllll.co/t/glut/21175/11",
-      "tags": ["granular"],
-      "origin": "lines"
+      "tags": ["granular"]
     },
     {
       "project_name": "granchild",
       "project_url": "https://github.com/schollz/granchild",
       "author": "Zack Scholl (infinitedigits)",
       "description": "quantized granular sequencer",
-      "discussion_url": "https://llllllll.co/t/granchild/41894",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/granchild/41894"
     },
     {
       "project_name": "grendy",
@@ -513,8 +459,7 @@
       "author": "Colin Drake (cfd90)",
       "description": "simple drone synth, grendel drone commander inspired",
       "discussion_url": "https://llllllll.co/t/31721",
-      "tags": ["synth", "midi"],
-      "origin": "lines"
+      "tags": ["synth", "midi"]
     },
     {
       "project_name": "grd",
@@ -522,16 +467,14 @@
       "author": "Yota Morimoto",
       "description": "sprayed multi-sampled celesta",
       "discussion_url": "https://llllllll.co/t/grd/33768",
-      "tags": ["synth", "granular"],
-      "origin": "lines"
+      "tags": ["synth", "granular"]
     },
     {
       "project_name": "greyhole",
       "project_url": "https://github.com/justmat/greyhole",
       "author": "Mat (Justmat)",
       "description": "echo / delay",
-      "discussion_url": "https://llllllll.co/t/greyhole/27687",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/greyhole/27687"
     },
     {
       "project_name": "gridstep",
@@ -539,8 +482,7 @@
       "author": "Michael P Jones (Quixotic7)",
       "description": "16 track isomorphic grid sequencer for timber and midi",
       "discussion_url": "https://llllllll.co/t/38559",
-      "tags": ["grid", "midi", "sequencer", "sampler"],
-      "origin": "lines"
+      "tags": ["grid", "midi", "sequencer", "sampler"]
     },
     {
       "project_name": "grid-test",
@@ -548,8 +490,7 @@
       "author": "Steven Noreyko (okyeron)",
       "description": "A utility script for testing grids",
       "discussion_url": "https://llllllll.co/t/grid-test/29346",
-      "tags": ["grid"],
-      "origin": "lines"
+      "tags": ["grid"]
     },
     {
       "project_name": "haven",
@@ -557,8 +498,7 @@
       "author": "LFSaw",
       "description": "a safe space?",
       "discussion_url": "https://llllllll.co/t/haven/21285",
-      "tags": ["synth", "noise"],
-      "origin": "lines"
+      "tags": ["synth", "noise"]
     },
     {
       "project_name": "hachi",
@@ -566,8 +506,7 @@
       "author": "pangrus",
       "description": "euclidean drum machine emulating the TR-808 sound",
       "discussion_url": "https://llllllll.co/t/35947",
-      "tags": ["lib", "drum"],
-      "origin": "lines"
+      "tags": ["lib", "drum"]
     },
     {
       "project_name": "haze",
@@ -575,8 +514,7 @@
       "author": "Szymon Kaliski",
       "description": "four track live granular looper",
       "discussion_url": "https://llllllll.co/t/haze/41781",
-      "tags": ["granular", "looper"],
-      "origin": "lines"
+      "tags": ["granular", "looper"]
     },
     {
       "project_name": "here-there",
@@ -584,8 +522,7 @@
       "author": "Caulen (speakerdamage)",
       "description": "the sound begins here but you began there",
       "discussion_url": "https://llllllll.co/t/here-there/36170",
-      "tags": ["softcut", "sines", "granular"],
-      "origin": "lines"
+      "tags": ["softcut", "sines", "granular"]
     },
     {
       "project_name": "hid_demo",
@@ -593,16 +530,14 @@
       "author": "steven noreyko (okyeron)",
       "description": "demo scripts for hid functionality",
       "discussion_url": "https://llllllll.co/t/hid-demo/21315",
-      "tags": ["hid", "demo"],
-      "origin": "lines"
+      "tags": ["hid", "demo"]
     },
     {
       "project_name": "icarus",
       "project_url": "https://github.com/schollz/icarus",
       "author": "Zack Scholl (infinitedigits)",
       "description": "supersaw synth with feedback",
-      "discussion_url": "https://llllllll.co/t/icarus/43271",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/icarus/43271"
     },
     {
       "project_name": "islands",
@@ -610,8 +545,7 @@
       "author": "mark john williamson (junklight)",
       "description": "fm7, earthsea, kria, looper",
       "discussion_url": "https://llllllll.co/t/islands-0-1/30234",
-      "tags": ["grid"],
-      "origin": "lines"
+      "tags": ["grid"]
     },
     {
       "project_name": "isoseq",
@@ -619,8 +553,7 @@
       "author": "Randy Brown (carvingcode)",
       "description": "isomorphic qequencer for norns and grid",
       "discussion_url": "https://llllllll.co/t/isoseq/21026",
-      "tags": ["grid"],
-      "origin": "lines"
+      "tags": ["grid"]
     },
     {
       "project_name": "jala",
@@ -628,32 +561,28 @@
       "author": "Ulf Bögeholz (ulfster)",
       "description": "ambient random sequencer",
       "discussion_url": "https://llllllll.co/t/jala/41788",
-        "tags": ["midi", "sequencer"],
-      "origin": "lines"
+        "tags": ["midi", "sequencer"]
     },
     {
       "project_name": "jiffy",
       "project_url": "https://github.com/lukes-anger/jiffy",
       "author": "Luke Sanger (Molotov)",
       "description": "16 second looper",
-      "discussion_url": "https://llllllll.co/t/jiffy/25475",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/jiffy/25475"
     },
     {
       "project_name": "just-play",
       "project_url": "https://github.com/midouest/just-play",
       "author": "Robin (midouest)",
       "description": "play just friends with midi",
-      "discussion_url": "https://llllllll.co/t/just-play/33979",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/just-play/33979"
     },
     {
       "project_name": "kolor",
       "project_url": "https://github.com/schollz/kolor",
       "author": "Zack Scholl (infinitedigits)",
       "description": "grid-based sample sequencer",
-      "discussion_url": "https://llllllll.co/t/kolor/40504",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/kolor/40504"
     },
     {
       "project_name": "kria_midi",
@@ -661,16 +590,14 @@
       "author": "mark john williamson (junklight)",
       "description": "port of kria from ansible",
       "discussion_url": "https://llllllll.co/t/21255",
-      "tag": ["grid", "midi"],
-      "origin": "lines"
+      "tag": ["grid", "midi"]
     },
     {
       "project_name": "larc",
       "project_url": "https://github.com/justmat/larc",
       "author": "Mat (justmat)",
       "description": "looper/delay",
-      "discussion_url": "https://llllllll.co/t/larc/39790",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/larc/39790"
     },
     {
       "project_name": "less_concepts",
@@ -678,8 +605,7 @@
       "author": "jai lai bookie (Dan_Derks)",
       "description": "1d cellular automata sequencer",
       "discussion_url": "https://llllllll.co/t/21109",
-      "tags": ["ca", "crow", "sequencer"],
-      "origin": "lines"
+      "tags": ["ca", "crow", "sequencer"]
     },
     {
       "project_name": "less_concepts_3",
@@ -687,8 +613,7 @@
       "author": "dan derks (@dan_derks) & linus schrab (@vicimity)",
       "description": "1d cellular automata sequencer",
       "discussion_url": "https://llllllll.co/t/less-concepts-3/",
-      "tags": ["ca", "crow", "midi", "sequencer"],
-      "origin": "lines"
+      "tags": ["ca", "crow", "midi", "sequencer"]
     },
     {
       "project_name": "lissadron",
@@ -696,8 +621,7 @@
       "author": "LFSaw",
       "description": "seeding fields forever",
       "discussion_url": "https://llllllll.co/t/lissadron/32509",
-      "tags": ["synth", "random"],
-      "origin": "lines"
+      "tags": ["synth", "random"]
     },
     {
       "project_name": "loom",
@@ -705,8 +629,7 @@
       "author": "Mark Eats (markeats)",
       "description": "pattern weaving sequencer for grids",
       "discussion_url": "https://llllllll.co/t/loom/21091",
-      "tags": ["grid"],
-      "origin": "lines"
+      "tags": ["grid"]
     },
     {
       "project_name": "m18s",
@@ -714,8 +637,7 @@
       "author": "John Mitchell (jlmitch5)",
       "description": "a sequencer based on the RYK M-185",
       "discussion_url": "https://llllllll.co/t/m18s-now-for-norns/32068",
-      "tags": ["synth", "midi", "crow"],
-      "origin": "lines"
+      "tags": ["synth", "midi", "crow"]
     },
     {
       "project_name": "mangl",
@@ -723,8 +645,7 @@
       "author": "Mat (Justmat)",
       "description": "a 4 track granular sample player",
       "discussion_url": "https://llllllll.co/t/21066",
-      "tags": ["arc", "granular"],
-      "origin": "lines"
+      "tags": ["arc", "granular"]
     },
     {
       "project_name": "manifold",
@@ -732,8 +653,7 @@
       "author": "Carl Testa (carltesta)",
       "description": "multi-effects processing for live performance",
       "discussion_url": "https://llllllll.co/t/manifold/22098",
-      "tags": ["fx"],
-      "origin": "lines"
+      "tags": ["fx"]
     },
     {
       "project_name": "meadowphysics",
@@ -741,16 +661,14 @@
       "author": "Ryan Hodgman (alphacactus), Dan Sim (dansimco)",
       "description": "grid-enabled rhizomatic cascading counter",
       "discussion_url": "https://llllllll.co/t/21185",
-      "tags": ["grid"],
-      "origin": "lines"
+      "tags": ["grid"]
     },
     {
       "project_name": "metrix",
       "project_url": "https://github.com/kasperbauer/metrix",
       "author": "Christian Kasperbauer (kasperbauer)",
       "description": "it's like metropolix for norns",
-      "tags": ["sequencer", "grid", "crow", "midi"],
-      "origin": "lines"
+      "tags": ["sequencer", "grid", "crow", "midi"]
     },
     {
       "project_name": "midi-monitor",
@@ -758,8 +676,7 @@
       "author": "Steven Noreyko (okyeron)",
       "description": "A MIDI monitor for norns",
       "discussion_url": "https://llllllll.co/t/midi-monitor/35036",
-      "tags": ["midi"],
-      "origin": "lines"
+      "tags": ["midi"]
     },
     {
       "project_name": "mlr",
@@ -767,8 +684,7 @@
       "author": "Brian Crabtree (tehn)",
       "description": "live sample-cutting platform",
       "discussion_url": "https://llllllll.co/t/21145",
-      "tags": ["sampler"],
-      "origin": "lines"
+      "tags": ["sampler"]
     },
     {
       "project_name": "molly_the_poly",
@@ -776,8 +692,7 @@
       "author": "Mark Eats (markeats)",
       "description": "classic polysynth with solar system patch creator",
       "discussion_url": "https://llllllll.co/t/molly-the-poly/21090",
-      "tags": ["synth", "midi"],
-      "origin": "lines"
+      "tags": ["synth", "midi"]
     },
     {
       "project_name": "moln",
@@ -785,8 +700,7 @@
       "author": "Anton Hörnquist (jah)",
       "description": "polyphonic subtractive synthesizer",
       "discussion_url": "https://llllllll.co/t/moln/21111",
-      "tags": ["synth", "midi", "grid", "arc"],
-      "origin": "lines"
+      "tags": ["synth", "midi", "grid", "arc"]
     },
     {
       "project_name": "monitor",
@@ -794,8 +708,7 @@
       "author": "Devine Lu Linvega (neauoire)",
       "description": "small kit of midi utilities to transpose and route midi messages",
       "discussion_url": "https://llllllll.co/t/23273",
-      "tags": ["midi"],
-      "origin": "lines"
+      "tags": ["midi"]
     },
     {
       "project_name": "mouse",
@@ -803,8 +716,7 @@
       "author": "Colin Drake (cfd90)",
       "description": "sound maker and sequencer heavily inspired by Laurie Spiegel's Music Mouse",
       "discussion_url": "https://llllllll.co/t/mouse/41562",
-      "tags": ["synth", "sequencer", "grid"],
-      "origin": "lines"
+      "tags": ["synth", "sequencer", "grid"]
     },
     {
       "project_name": "msh",
@@ -812,16 +724,14 @@
       "author": "andrew",
       "description": "extensible grid keyboard",
       "discussion_url": "https://llllllll.co/t/msh",
-      "tags": ["grid"],
-      "origin": "lines"
+      "tags": ["grid"]
     },
     {
       "project_name": "mx.samples",
       "project_url": "https://github.com/schollz/mx.samples",
       "author": "Zack Scholl (infinitedigits)",
       "description": "like mr.radar or mr.coffee but for samples",
-      "discussion_url": "https://llllllll.co/t/mx-samples/41400",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/mx-samples/41400"
     },
     {
       "project_name": "n16o",
@@ -829,8 +739,7 @@
       "author": "John Mitchell (jlmitch5)",
       "description": "i2c-based ER-301 control via KORG nanoKONTROL2",
       "discussion_url": "https://llllllll.co/t/n16o/28198",
-      "tags": ["crow", "ER-301", "nanoKONTROL 2"],
-      "origin": "lines"
+      "tags": ["crow", "ER-301", "nanoKONTROL 2"]
     },
     {
       "project_name": "nisp",
@@ -845,40 +754,35 @@
       "project_url": "https://github.com/frederickk/noergaard",
       "author": "Ken Frederick (frederickk)",
       "description": "A small library to generate Nørgård infinity sequences for Norns",
-      "tags": ["generative", "library", "norgard", "midi"],
-      "origin": "lines"
+      "tags": ["generative", "library", "norgard", "midi"]
     },
     {
       "project_name": "norman",
       "project_url": "https://github.com/crimclark/norman",
       "author": "crim",
       "description": "simple audio utility",
-      "discussion_url": "https://llllllll.co/t/norman/22606",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/norman/22606"
     },
     {
       "project_name": "norns.online",
       "project_url": "https://github.com/schollz/norns.online",
       "author": "Zack Scholl (infinitedigits)",
       "description": "remotely control norns from the browser",
-      "discussion_url": "https://llllllll.co/t/norns-online/38547",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/norns-online/38547"
     },
     {
       "project_name": "nc01-drone",
       "project_url": "https://github.com/monome-community/nc01-drone",
       "author": "norns community",
       "description": "norns/circle/01 drone in three worlds",
-      "discussion_url": "https://llllllll.co/t/norns-circle-01-drone-in-three-worlds/28582",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/norns-circle-01-drone-in-three-worlds/28582"
     },
     {
       "project_name": "nc02-rs",
       "project_url": "https://github.com/monome-community/nc02-rs",
       "author": "norns community",
       "description": "norns/circle/02 rhythm and sound",
-      "discussion_url": "https://llllllll.co/t/norns-circle-02-rhythm-and-sound/31645",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/norns-circle-02-rhythm-and-sound/31645"
     },
     {
       "project_name": "onehanded",
@@ -886,24 +790,21 @@
       "author": "Nathan (mimetaur)",
       "description": "minimal manual controller script",
       "discussion_url": "https://llllllll.co/t/onehanded/25869",
-      "tags": ["midi"],
-      "origin": "lines"
+      "tags": ["midi"]
     },
     {
       "project_name": "oooooo",
       "project_url": "https://github.com/schollz/oooooo",
       "author": "Zack Scholl (infinitedigits)",
       "description": "digital tape loops, x 6",
-      "discussion_url": "https://llllllll.co/t/oooooo",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/oooooo"
     },
     {
       "project_name": "orbital",
       "project_url": "https://github.com/P1505/orbital",
       "author": "P1505",
       "description": "orbital is an experiment in simple sequences and interface design",
-      "discussion_url": "https://llllllll.co/t/orbital-norns/21379",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/orbital-norns/21379"
     },
     {
       "project_name": "orca",
@@ -911,8 +812,7 @@
       "author": "its your bedtime (its_your_bedtime)",
       "description": "visual programming language, designed to create procedural sequencers on the fly",
       "discussion_url": "https://llllllll.co/t/22492",
-      "tags": ["hid", "keyboard"],
-      "origin": "lines"
+      "tags": ["hid", "keyboard"]
     },
     {
       "project_name": "ortf",
@@ -920,8 +820,7 @@
       "author": "felart",
       "description": "Sort of Radio music clone where each audio file in tape folder is a station",
       "discussion_url": "https://llllllll.co/t/ortf/39694",
-      "tags": ["midi"],
-      "origin": "lines"
+      "tags": ["midi"]
     },
     {
       "project_name": "otis",
@@ -929,8 +828,7 @@
       "author": "Mat (Justmat)",
       "description": "dual tape delay/looper/sampler",
       "discussion_url": "https://llllllll.co/t/22149",
-      "tags": ["looper"],
-      "origin": "lines"
+      "tags": ["looper"]
     },
     {
       "project_name": "passersby",
@@ -938,8 +836,7 @@
       "author": "Mark Eats (markeats)",
       "description": "west coast style mono synth",
       "discussion_url": "https://llllllll.co/t/passersby/21089",
-      "tags": ["synth", "midi"],
-      "origin": "lines"
+      "tags": ["synth", "midi"]
     },
     {
       "project_name": "passthrough",
@@ -947,8 +844,7 @@
       "author": "Guy (nattog)",
       "description": "midi passthrough library with examples",
       "discussion_url": "https://llllllll.co/t/passthrough/31156",
-      "tags": ["midi"],
-      "origin": "lines"
+      "tags": ["midi"]
     },
     {
       "project_name": "patchwork",
@@ -956,8 +852,7 @@
       "author": "Olivier",
       "description": "dual function sequencer for monome norns, crow and grid",
       "discussion_url": "https://llllllll.co/t/patchwork/28800",
-      "tags": ["sequencer", "grid", "crow"],
-      "origin": "lines"
+      "tags": ["sequencer", "grid", "crow"]
     },
     {
       "project_name": "pedalboard",
@@ -965,16 +860,14 @@
       "author": "David Kettler (21echoes)",
       "description": "chainable effects for live performance",
       "discussion_url": "https://llllllll.co/t/31119",
-      "tags": ["fx"],
-      "origin": "lines"
+      "tags": ["fx"]
     },
     {
       "project_name": "phyllis",
       "project_url": "https://github.com/justmat/phyllis",
       "author": "Mat (justmat)",
       "description": "a digitally modeled analog filter",
-      "discussion_url": "https://llllllll.co/t/27988",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/27988"
     },
     {
       "project_name": "pitfalls",
@@ -982,8 +875,7 @@
       "author": "Rob (delineator)",
       "description": "microtonal scale explorer / arpeggiator / grid keyboard",
       "discussion_url": "https://llllllll.co/t/pitfalls/37795",
-      "tags": ["grid"],
-      "origin": "lines"
+      "tags": ["grid"]
     },
     {
       "project_name": "piwip",
@@ -991,8 +883,7 @@
       "author": "Zack Scholl (infinitedigits)",
       "description": "a sampler that works in realtime",
       "discussion_url": "https://llllllll.co/t/piwip/36642",
-      "tags": ["midi"],
-      "origin": "lines"
+      "tags": ["midi"]
     },
     {
       "project_name": "pixels",
@@ -1007,24 +898,21 @@
       "project_url": "https://github.com/schollz/plonky",
       "author": "Zack Scholl (infinitedigits)",
       "description": "string-like keyboard and sequencer",
-      "discussion_url": "https://llllllll.co/t/plonky/42520",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/plonky/42520"
     },
     {
       "project_name": "pools",
       "project_url": "https://github.com/justmat/pools",
       "author": "Mat (justmat)",
       "description": "a shimmery reverb",
-      "discussion_url": "https://llllllll.co/t/28320",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/28320"
     },
     {
       "project_name": "punchcard",
       "project_url": "https://github.com/neauoire/punchcard",
       "author": "Devine Lu Linvega (neauoire)",
       "description": "an experimental sequencer that works a bit like the classic punchcard computer",
-      "discussion_url": "https://llllllll.co/t/23557",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/23557"
     },
     {
       "project_name": "qfwfq",
@@ -1032,8 +920,7 @@
       "author": "Casey Childers (notester)",
       "description": "A brute-force password hack inspired sequencer.",
       "discussion_url": "https://llllllll.co/t/qfwfq",
-      "tags": ["sequencer", "midi"],
-      "origin": "lines"
+      "tags": ["sequencer", "midi"]
     },
     {
       "project_name": "quence",
@@ -1041,8 +928,7 @@
       "author": "Rob Schoen",
       "description": "probabilistic 4-track sequencer",
       "discussion_url": "https://llllllll.co/t/quence/29436",
-      "tags": ["grid", "sequencer"],
-      "origin": "lines"
+      "tags": ["grid", "sequencer"]
     },
     {
       "project_name": "reels",
@@ -1050,8 +936,7 @@
       "author": "its your bedtime (its_your_bedtime)",
       "description": "a 4-track asynchronous looper, inspired by op-1 tape recorder and mannequins w/ eurorack module.",
       "discussion_url": "https://llllllll.co/t/21030",
-      "tags": ["looper"],
-      "origin": "lines"
+      "tags": ["looper"]
     },
     {
       "project_name": "r",
@@ -1066,8 +951,7 @@
       "author": "nf (enneff)",
       "description": "a kinetic sequencer",
       "discussion_url": "https://llllllll.co/t/23243",
-      "tags": ["sequencer"],
-      "origin": "lines"
+      "tags": ["sequencer"]
     },
     {
       "project_name": "rudiments",
@@ -1075,16 +959,14 @@
       "author": "Colin Drake (cfd90)",
       "description": "an 8 voice lofi percussion synthesizer and sequencer",
       "discussion_url": "https://llllllll.co/t/31828",
-      "tags": ["drum", "synth", "sequencer"],
-      "origin": "lines"
+      "tags": ["drum", "synth", "sequencer"]
     },
     {
       "project_name": "sam",
       "project_url": "https://github.com/justmat/sam",
       "author": "Mat (Justmat)",
       "description": "a simple sample recorder/slicer",
-      "discussion_url": "https://llllllll.co/t/23943",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/23943"
     },
     {
       "project_name": "samsara",
@@ -1092,8 +974,7 @@
       "author": "David Kettler (21echoes)",
       "description": "a minimalist clock-synced looper",
       "discussion_url": "https://llllllll.co/t/34095",
-      "tags": ["looper"],
-      "origin": "lines"
+      "tags": ["looper"]
     },
     {
       "project_name": "seaflex",
@@ -1101,8 +982,7 @@
       "author": "Lyle Mills (lylem)",
       "description": "companion app for earthsea",
       "discussion_url": "https://llllllll.co/t/23209",
-      "tags": ["grid"],
-      "origin": "lines"
+      "tags": ["grid"]
     },
     {
       "project_name": "silos",
@@ -1110,8 +990,7 @@
       "author": "mat (justmat)",
       "description": "live grains",
       "discussion_url": "https://llllllll.co/t/43804",
-      "tags": ["granular", "grid", "arc"],
-      "origin": "lines"
+      "tags": ["granular", "grid", "arc"]
     },
     {
       "project_name": "sines",
@@ -1119,8 +998,7 @@
       "author": "Aidan Reilly (oootini)",
       "description": "16 sine waves",
       "discussion_url": "https://llllllll.co/t/39292",
-      "tags": ["drone", "midi"],
-      "origin": "lines"
+      "tags": ["drone", "midi"]
     }, 
     {
       "project_name": "shfts",
@@ -1128,24 +1006,21 @@
       "author": "Richard Whaling (germinal)",
       "description": "random sequencer for norns, crow, and grid",
       "discussion_url": "https://llllllll.co/t/26221",
-      "tags": ["crow", "grid"],
-      "origin": "lines"
+      "tags": ["crow", "grid"]
     },
     {
       "project_name": "showers",
       "project_url": "https://github.com/justmat/showers",
       "author": "Mat (Justmat)",
       "description": "a thunderstorm for norns",
-      "discussion_url": "https://llllllll.co/t/31622",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/31622"
     },
     {
       "project_name": "skylines",
       "project_url": "https://github.com/unit-cell/skylines",
       "author": "Markel Martinez (markel_m)",
       "description": "a sequencer inspired on the M185/Intellijel Metropolis",
-      "discussion_url": "https://llllllll.co/t/skylines/38856",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/skylines/38856"
     },
     {
       "project_name": "spirals",
@@ -1153,24 +1028,21 @@
       "author": "tomw",
       "description": "sequencer",
       "discussion_url": "https://llllllll.co/t/spirals/40678",
-      "tags": ["sequencer"],
-      "origin": "lines"
+      "tags": ["sequencer"]
     },
     {
       "project_name": "stack",
       "project_url": "https://github.com/cfdrake/stack",
       "author": "Colin Drake (cfd90)",
       "description": "a stack of 8 fixed-frequency resonant bandpass filters",
-      "discussion_url": "https://llllllll.co/t/35218",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/35218"
     },
     {
       "project_name": "step",
       "project_url": "https://github.com/antonhornquist/step",
       "author": "Anton Hörnquist (jah)",
       "description": "a simple step sequencer",
-      "discussion_url": "https://llllllll.co/t/step/21093",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/step/21093"
     },
     {
       "project_name": "stjörnuíþrótt",
@@ -1178,24 +1050,21 @@
       "author": "Ken Frederick (frederickk)",
       "description": "drone inspired by Moffenzeef Stargazer",
       "discussion_url": "https://llllllll.co/t/33889",
-      "tags": ["drone", "midi"],
-      "origin": "lines"
+      "tags": ["drone", "midi"]
     },
     {
       "project_name": "strides",
       "project_url": "https://github.com/notjustmat/strides",
       "author": "Mat (Justmat)",
       "description": "a collection of pattern recorders",
-      "discussion_url": "https://llllllll.co/t/21101",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/21101"
     },
     {
       "project_name": "strum",
       "project_url": "https://github.com/carvingCode/strum",
       "author": "Randy Brown (carvingcode)",
       "description": "a plucky little pattern sequencer",
-      "discussion_url": "https://llllllll.co/t/21025",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/21025"
     },
     {
       "project_name": "supercut",
@@ -1203,24 +1072,21 @@
       "author": "andrew",
       "description": "softcut wrapper lib / voice management utility",
       "discussion_url": "https://llllllll.co/t/supercut-lib",
-      "tags": ["softcut", "lib"],
-      "origin": "lines"
+      "tags": ["softcut", "lib"]
     },
     {
       "project_name": "sway",
       "project_url": "https://github.com/carltesta/sway",
       "author": "Carl Testa (carltesta)",
       "description": "analysis-driven live audio processing",
-      "discussion_url": "https://llllllll.co/t/sway/21117",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/sway/21117"
     },
     {
       "project_name": "takt",
       "project_url": "https://github.com/itsyourbedtime/takt",
       "author": "igor (its_your_bedtime)",
       "description": "parameter locking step sequencer",
-      "discussion_url": "https://llllllll.co/t/takt/21032",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/takt/21032"
     },
     {
       "project_name": "tambla",
@@ -1243,16 +1109,14 @@
       "project_url": "https://github.com/markwheeler/timber",
       "author": "Mark Eats (markeats)",
       "description": "sample player engine and scripts",
-      "discussion_url": "https://llllllll.co/t/21407",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/21407"
     },
     {
       "project_name": "timeparty",
       "project_url": "https://github.com/crimclark/timeparty",
       "author": "crim",
       "description": "grid based delay sequencer",
-      "discussion_url": "https://llllllll.co/t/timeparty/22837",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/timeparty/22837"
     },
     {
       "project_name": "tmi",
@@ -1260,8 +1124,7 @@
       "author": "Zack Scholl (infinitedigits)",
       "description": "library for sequencing midi with text",
       "discussion_url": "https://llllllll.co/t/tmi/40818",
-      "tags": ["midi"],
-      "origin": "lines"
+      "tags": ["midi"]
     },
     {
       "project_name": "torii",
@@ -1269,32 +1132,28 @@
       "author": "Steven Noreyko (okyeron)",
       "description": "gated audio sequencer",
       "discussion_url": "https://llllllll.co/t/torii/30476",
-      "tags": ["grid", "sequencer", "midi", "link"],
-      "origin": "lines"
+      "tags": ["grid", "sequencer", "midi", "link"]
     },
     {
       "project_name": "traffic",
       "project_url": "https://github.com/ypxk/traffic",
       "author": "ypxkap",
       "description": "edit of @markeats loom for quickly decoupling motifs from their harmonic framework",
-      "discussion_url": "https://llllllll.co/t/traffic/21262",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/traffic/21262"
     },
     {
       "project_name": "tuner",
       "project_url": "https://github.com/markwheeler/tuner",
       "author": "Mark Eats (markeats)",
       "description": "tune stuff",
-      "discussion_url": "https://llllllll.co/t/tuner/21088",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/tuner/21088"
     },
     {
       "project_name": "tunnels",
       "project_url": "https://github.com/speakerdamage/tunnels",
       "author": "Caulen (speakerdamage)",
       "description": "a collection of uncertain delays using norns softcut",
-      "discussion_url": "https://llllllll.co/t/tunnels/21973",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/tunnels/21973"
     },
     {
       "project_name": "twine",
@@ -1302,8 +1161,7 @@
       "author": "Colin Drake (cfd90)",
       "description": "random granulator for two samples",
       "discussion_url": "https://llllllll.co/t/41703",
-      "tags": ["granular"],
-      "origin": "lines"
+      "tags": ["granular"]
     },
     {
       "project_name": "uhf",
@@ -1311,16 +1169,14 @@
       "author": "Caulen (speakerdamage)",
       "description": "your tapes transmitted thru late-night static and broken antenna frequencies",
       "discussion_url": "https://llllllll.co/t/uhf-norns/21154",
-      "tags": ["tape"],
-      "origin": "lines"
+      "tags": ["tape"]
     },
     {
       "project_name": "vials",
       "project_url": "https://github.com/nattog/vials",
       "author": "Guy (nattog)",
       "description": "4 track performance-oriented sample sequencer",
-      "discussion_url": "https://llllllll.co/t/vials/23109",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/vials/23109"
     },
     {
       "project_name": "wrms",
@@ -1328,8 +1184,7 @@
       "author": "andrew",
       "description": "dual asyncronous time-wigglers / echo loopers",
       "discussion_url": "https://llllllll.co/t/wrms/28954",
-      "tags": ["softcut", "looper", "delay"],
-      "origin": "lines"
+      "tags": ["softcut", "looper", "delay"]
     },
     {
       "project_name": "yggdrasil",
@@ -1337,16 +1192,14 @@
       "author": "@argotechnica, @infinitedigits, @license, @tyleretters",
       "description": "a norns cyberdeck tracker",
       "discussion_url": "https://l.llllllll.co/yggdrasil",
-      "tags": ["tracker"],
-      "origin": "lines"
+      "tags": ["tracker"]
     },
     {
       "project_name": "zellen",
       "project_url": "https://github.com/sarweiler/zellen",
       "author": "Sven (sbaio)",
       "description": "game of life based sequencer",
-      "discussion_url": "https://llllllll.co/t/zellen/21107",
-      "origin": "lines"
+      "discussion_url": "https://llllllll.co/t/zellen/21107"
     },
     {
       "project_name": "initenere",
@@ -1354,8 +1207,7 @@
       "author": "Linus Schrab (@vicimity)",
       "description": "2-dimensional polyrythmic, random note sequencer.",
       "discussion_url": "https://llllllll.co/t/initenere/41193",
-      "tags": ["sequencer", "crow"],
-      "origin": "lines"
+      "tags": ["sequencer", "crow"]
     },
     {
       "project_name": "nest_",
@@ -1363,8 +1215,7 @@
       "author": "andrew",
       "description": "a language of touch for objects by monome",
       "discussion_url": "https://llllllll.co/t/nest",
-      "tags": ["grid", "arc", "lib"],
-      "origin": "lines"
+      "tags": ["grid", "arc", "lib"]
     }
   ]
 }


### PR DESCRIPTION
the origin property is a left over from an experimental forum scraping feature which never worked well enough to use as the canonical source of scripts. the initial catalog was built using the "lines" scraper and everyone has been manually copying the origin property ever since...

this cleans out the cruft 