### PR TITLE
merge less_concepts_3 into less_concepts

### DIFF
--- a/community.json
+++ b/community.json
@@ -819,14 +819,6 @@
     {
       "project_name": "less_concepts",
       "project_url": "https://github.com/dndrks/less_concepts",
-      "author": "jai lai bookie (Dan_Derks)",
-      "description": "1d cellular automata sequencer",
-      "discussion_url": "https://llllllll.co/t/21109",
-      "tags": ["ca", "crow", "sequencer"]
-    },
-    {
-      "project_name": "less_concepts_3",
-      "project_url": "https://github.com/linusschrab/less_concepts_3",
       "author": "dan derks (@dan_derks) & linus schrab (@vicimity)",
       "description": "1d cellular automata sequencer",
       "discussion_url": "https://llllllll.co/t/less-concepts-3/",

--- a/community.json
+++ b/community.json
@@ -817,9 +817,9 @@
       "documentation_url": "https://norns.community/authors/justmat/larc"
     },
     {
-      "project_name": "less_concepts",
-      "project_url": "https://github.com/dndrks/less_concepts",
-      "author": "dan derks (@dan_derks) & linus schrab (@vicimity)",
+      "project_name": "less-concepts",
+      "project_url": "https://github.com/vicimity-dndrks/less_concepts",
+      "author": "linus schrab (@vicimity) & dan derks (@dan_derks)",
       "description": "1d cellular automata sequencer",
       "discussion_url": "https://llllllll.co/t/less-concepts-3/",
       "documentation_url": "https://norns.community/authors/collabs/lessconcepts3",


### PR DESCRIPTION
related to #197 -- i think the least painful approach is removing both less concepts entries and just updating the authorship + discussion info for `less-concepts`, since the two scripts have been merged + migrated into the main repo