### PR TITLE
Update community.json

### DIFF
--- a/community.json
+++ b/community.json
@@ -422,7 +422,7 @@
     {
       "project_name": "carter's delay",
       "project_url": "https://github.com/williamthazard/carters-delay-norns",
-      "author": "William Hazard",
+      "author": "WilliamHazard",
       "description": "a simple multi-tap delay for the young and young at heart",
       "discussion_url": "https://llllllll.co/t/carters-delay-norns/68307",
       "tags": [


### PR DESCRIPTION
I accidentally entered the author name for carter's delay as "William Hazard." This commit changes it to "WilliamHazard," to match my other contributions here