### PR TITLE
Create trigger-website-build.yml

### DIFF
--- a/.github/workflows/trigger-website-build.yml
+++ b/.github/workflows/trigger-website-build.yml
@@ -1,0 +1,19 @@
+name: "Trigger https://norns.community Build"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger_build_via_norns_community_merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Trigger https://norns.community Build"
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github.everest-preview+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -d '{"event_type": "trigger_build_via_norns_community_merge"}' \
+            https://api.github.com/repos/monome-community/norns-community/dispatches


### PR DESCRIPTION
what:

- trigger build of https://norns.community on merges to `main` or workflow dispatch

why:

- so contributors get to see their work show up quicker
- to partially help with the "60 days of inactivity" issue https://github.com/monome-community/norns-community/issues/21

how:

- github workflow
- need to ensure a GITHUB_TOKEN is setup in this repo