### PR TITLE
Add clockabout; add clock tag

### DIFF
--- a/community.json
+++ b/community.json
@@ -524,7 +524,8 @@
       "discussion_url": "https://llllllll.co/t/clarck/21251",
       "tags": [
         "utility",
-        "arc"
+        "arc",
+        "clock"
       ]
     },
     {
@@ -546,6 +547,14 @@
       "tags": [
         "sampler"
       ]
+    },
+    {
+      "project_name": "clockabout",
+      "project_url": "https://github.com/niksilver/clockabout",
+      "author": "Nik Silver (niksilver)",
+      "description": "A non-linear MIDI clock",
+      "discussion_url": "https://llllllll.co/t/clockabout/70820",
+      "tags": ["midi", "utilities", "clock"]
     },
     {
       "project_name": "colorwheel",


### PR DESCRIPTION
* Add the clockabout script, which is [already on the lines forum](https://llllllll.co/t/clockabout/70820).
* Include a `clock` tag which applies to this and at least one other script. (And there may be [another one](https://llllllll.co/t/use-norns-as-an-ableton-link-to-midi-clocker/68760) soon.)