### PR TITLE
Added monomaniac, a little utility for left-only audio sources.

### DIFF
--- a/community.json
+++ b/community.json
@@ -3701,6 +3701,15 @@
   "discussion_url": "https://llllllll.co/t/mnmpatch/71750",
   "documentation_url": "https://github.com/hanjo-synth/Mnmpatch",
   "tags": ["midi", "randomizer", "monomachine", "sound design", "hardware"]
-  }
+  },
+    {
+      "project_name": "monomaniac",
+      "project_url": "https://github.com/xmacex/monomaniac",
+      "author": "xmacex",
+      "description": "A mod to toggle stereo and mono input",
+      "discussion_url": "https://llllllll.co/t/monomaniac-a-mod-to-toggle-stereo-and-mono-input/63892",
+      "documentation_url": "https://github.com/xmacex/monomaniac",
+      "tags": ["mod", "utility"]
+    }
   ]
 }


### PR DESCRIPTION
Added monomaniac, a little utility for situations when an audio source is left-only (e.g. Eurorack).