### PR TITLE
add leslie

### DIFF
--- a/community.json
+++ b/community.json
@@ -1685,6 +1685,17 @@
       ]
     },
     {
+      "project_name": "leslie",
+      "project_url": "https://github.com/moapacha/leslie",
+      "author": "sym",
+      "description": "doppler, tremolo, and the slow spin-up",
+      "documentation_url": "https://github.com/moapacha/leslie/blob/main/README.md",
+      "tags": [
+        "audio_fx",
+        "engine"
+      ]
+    },
+    {
       "project_name": "less-concepts",
       "project_url": "https://github.com/vicimity-dndrks/less_concepts",
       "author": "vicimity dan_derks",


### PR DESCRIPTION
**project_name**: leslie
**author**: sym
**description**: doppler, tremolo, and the slow spin-up

A norns rotating-speaker effect modeled on the dual-rotor Leslie cabinet. Stereo input is split at an LR4 crossover into a horn band and a bass-drum band; each band runs through a doppler delay, AM tremolo, and counter-rotating stereo pan. Slow / fast / brake modes follow the Leslie 122 with smoothed spin-up / spin-down.

- repo: https://github.com/moapacha/leslie
- README: https://github.com/moapacha/leslie/blob/main/README.md
- screen.gif preview included in repo